### PR TITLE
refactor and test: refactor to prevent small liquidity

### DIFF
--- a/orca/lockbox/programs/liquidity_lockbox/src/lib.rs
+++ b/orca/lockbox/programs/liquidity_lockbox/src/lib.rs
@@ -272,9 +272,6 @@ pub mod liquidity_lockbox {
       return Err(ErrorCode::AmountExceedsPositionLiquidity.into());
     }
 
-    // Get the post-withdraw token remainder
-    let remainder: u64 = position_liquidity - amount;
-
     // Burn provided amount of bridged tokens
     invoke_signed(
       &burn_checked(
@@ -363,6 +360,9 @@ pub mod liquidity_lockbox {
       signer_seeds
     );
     whirlpool::cpi::decrease_liquidity(cpi_ctx_modify_liquidity, amount as u128, token_min_a, token_min_b)?;
+
+    // Get the post-withdraw token remainder
+    let remainder: u64 = position_liquidity - amount;
 
     // If requested amount can be fully covered by the current position liquidity, close the position
     if remainder == 0 {

--- a/orca/lockbox/programs/liquidity_lockbox/src/state.rs
+++ b/orca/lockbox/programs/liquidity_lockbox/src/state.rs
@@ -6,6 +6,10 @@ pub struct LiquidityLockbox {
   pub bump: [u8; 1],
   // Bridged token mint address
   pub bridged_token_mint: Pubkey,
+  // Fee collector ATA for token A
+  pub fee_collector_token_owner_account_a: Pubkey,
+  // Fee collector ATA for token B
+  pub fee_collector_token_owner_account_b: Pubkey,
   // Total liquidity in a lockbox
   // Considering OLAS and SOL inflation, it will never practically be bigger than 2^64 - 1
   pub total_liquidity: u64,
@@ -15,7 +19,7 @@ pub struct LiquidityLockbox {
 }
 
 impl LiquidityLockbox {
-  pub const LEN: usize = 8 + 1 + 32 + 8 + 4;
+  pub const LEN: usize = 8 + 1 + 32 * 3 + 8 + 4;
 
   pub fn seeds(&self) -> [&[u8]; 2] {
     [
@@ -27,9 +31,13 @@ impl LiquidityLockbox {
   pub fn initialize(
     &mut self,
     bump: u8,
-    bridged_token_mint: Pubkey
+    bridged_token_mint: Pubkey,
+    fee_collector_token_owner_account_a: Pubkey,
+    fee_collector_token_owner_account_b: Pubkey
   ) -> Result<()> {
     self.bridged_token_mint = bridged_token_mint;
+    self.fee_collector_token_owner_account_a = fee_collector_token_owner_account_a;
+    self.fee_collector_token_owner_account_b = fee_collector_token_owner_account_b;
     self.total_liquidity = 0;
     self.num_positions = 0;
     self.bump = [bump];

--- a/orca/lockbox/tests/liquidity_lockbox.ts
+++ b/orca/lockbox/tests/liquidity_lockbox.ts
@@ -432,10 +432,11 @@ async function main() {
     // ############################## WITHDRAW ##############################
     console.log("\nSending bridged tokens back to the program in exchange of the liquidity split in both tokens");
 
+    const zeroAmount = new anchor.BN("0");
     const bigBalance = new anchor.BN("4000000000");
     // Try to get amounts and positions for a bigger provided liquidity amount than the total liquidity
     try {
-        signature = await program.methods.withdraw(bigBalance)
+        signature = await program.methods.withdraw(numPosition, bigBalance, zeroAmount, zeroAmount)
           .accounts(
               {
                 lockbox: pdaProgram,
@@ -465,7 +466,7 @@ async function main() {
 
     // Try to execute the withdraw with the incorrect position address
     try {
-        signature = await program.methods.withdraw(tBalalnce)
+        signature = await program.methods.withdraw(numPosition, tBalalnce, zeroAmount, zeroAmount)
           .accounts(
               {
                 lockbox: pdaProgram,
@@ -506,7 +507,7 @@ async function main() {
     // Execute the correct withdraw tx
     console.log("Amount of bridged tokens to withdraw:", tBalalnce.toString());
     try {
-        signature = await program.methods.withdraw(tBalalnce)
+        signature = await program.methods.withdraw(numPosition, tBalalnce, zeroAmount, zeroAmount)
           .accounts(
               {
                 lockbox: pdaProgram,


### PR DESCRIPTION
- Refactor to account for small liquidity and untie the strict positions id order;
- Updating tests;
- Updating docs.